### PR TITLE
docs: add README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+```markdown
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme project management documentation. This folder contains our living guides, templates, and playbooks for running cross-functional projects consistently and safely.
+
+OctoAcme runs projects through a lightweight, iterative lifecycle: Initiation (one‑pager to validate the problem, goals, stakeholders, and success metrics), Planning (kickoff, prioritized backlog, estimates, Definition of Done, and release mapping), Execution & Tracking (small, testable increments tracked on a project board with PR/CI conventions), Release & Deployment (pre-release checks, smoke tests, and rollback plans), and Close & Retrospective (capture learnings and convert them into action items). We emphasize iterative delivery, clear ownership, and data-informed decision making.
+
+Key workflows include using a project board with columns (Backlog → Ready → In Progress → In Review → QA → Done), a Pull Request workflow that favors small PRs and passing CI, and a risk register that is updated weekly and escalated through defined paths. Core roles (Project Manager, Product Manager, Developers, QA/Testing, and Stakeholders) each have defined responsibilities to ensure clear ownership of milestones, escalations, and communication.
+
+Communication and quality assurance are built into our cadence: daily standups, regular delivery syncs, sprint demos, weekly PM+PdM alignment, monthly stakeholder updates, and incident comms. QA expectations include unit and integration tests, security scanning in CI, manual QA as needed, and smoke tests for pre/post‑deploy verification. Retrospectives convert learnings into small, tracked action items to continuously improve the process.
+
+## Process documents
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+## Contributing
+
+To propose updates to these process docs, use the repository's "Add Content to Project Management Process Docs" issue template located in `.github/ISSUE_TEMPLATE/`. When you submit changes, link or reference the relevant process doc and include rationale and acceptance criteria.
+```


### PR DESCRIPTION
Adds docs/README.md with an overview and links to process documents. Closes #2.